### PR TITLE
Add mbed implementation for SystemTimeSupport.cpp

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -535,6 +535,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     } else if (chip_device_platform == "mbed") {
       sources += [
         "mbed/ConfigurationManagerImpl.cpp",
+        "mbed/SystemTimeSupport.cpp",
         "mbed/MbedConfig.cpp"
       ]
     }

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -133,7 +133,7 @@ Error SetClock_RealTime(uint64_t newCurTime)
         uint8_t month, dayOfMonth, hour, minute, second;
         SecondsSinceEpochToCalendarTime(tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
         ChipLogProgress(DeviceLayer,
-                        "Real time clock set to %ld (%04" PRId16 "/%02" PRId8 "/%02" PRId8 " %02" PRId8 ":%02" PRId8 ":%02" PRId8
+                        "Real time clock set to %ld (%04" PRIu16 "/%02" PRIu8 "/%02" PRIu8 " %02" PRIu8 ":%02" PRIu8 ":%02" PRIu8
                         " UTC)",
                         tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
     }

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -35,21 +35,43 @@ namespace System {
 namespace Platform {
 namespace Layer {
 
+/**
+ * Platform-specific function for getting monotonic system time in microseconds.
+ *
+ * @returns Elapsed time in microseconds since an arbitrary, platform-defined epoch.
+ */
 uint64_t GetClock_Monotonic()
 {
     return rtos::Kernel::get_ms_count() * UINT64_C(1000);
 }
 
+/**
+ * Platform-specific function for getting monotonic system time in milliseconds.
+ *
+ * @returns Elapsed time in milliseconds since an arbitrary, platform-defined epoch.
+ */
 uint64_t GetClock_MonotonicMS()
 {
     return rtos::Kernel::get_ms_count();
 }
 
+/**
+ * Platform-specific function for getting high-resolution monotonic system time in microseconds.
+ *
+ * @returns Elapsed time in microseconds since an arbitrary, platform-defined epoch.
+ */
 uint64_t GetClock_MonotonicHiRes()
 {
     return GetClock_Monotonic();
 }
 
+/**
+ * Platform-specific function for getting the current real (civil) time in microsecond Unix time
+ * format.
+ *
+ * @param[out] curTime      The current time, expressed as Unix time scaled to microseconds.
+ * @returns                 CHIP_SYSTEM_NO_ERROR if the method succeeded.
+ */
 Error GetClock_RealTime(uint64_t & curTime)
 {
     struct timeval tv;
@@ -66,6 +88,13 @@ Error GetClock_RealTime(uint64_t & curTime)
     return CHIP_SYSTEM_NO_ERROR;
 }
 
+/**
+ * Platform-specific function for getting the current real (civil) time in millisecond Unix time
+ * format.
+ *
+ * @param[out] curTimeMS    The current time, expressed as Unix time scaled to milliseconds.
+ * @returns                 CHIP_SYSTEM_NO_ERROR if the method succeeded.
+ */
 Error GetClock_RealTimeMS(uint64_t & curTimeMS)
 {
     struct timeval tv;
@@ -82,6 +111,12 @@ Error GetClock_RealTimeMS(uint64_t & curTimeMS)
     return CHIP_SYSTEM_NO_ERROR;
 }
 
+/**
+ * Platform-specific function for setting the current real (civil) time.
+ *
+ * @param[out] newCurTime   The new current time, expressed as Unix time scaled to microseconds.
+ * @returns                 CHIP_SYSTEM_NO_ERROR if the method succeeded.
+ */
 Error SetClock_RealTime(uint64_t newCurTime)
 {
     struct timeval tv;

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -1,0 +1,112 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides implementations of the CHIP System Layer platform
+ *          time/clock functions that are suitable for use on the Mbed-OS platform.
+ */
+/* this file behaves like a config.h, comes first */
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <support/TimeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+#include <Kernel.h>
+
+namespace chip {
+namespace System {
+namespace Platform {
+namespace Layer {
+
+uint64_t GetClock_Monotonic()
+{
+    return rtos::Kernel::get_ms_count() * UINT64_C(1000);
+}
+
+uint64_t GetClock_MonotonicMS()
+{
+    return rtos::Kernel::get_ms_count();
+}
+
+uint64_t GetClock_MonotonicHiRes()
+{
+    return GetClock_Monotonic();
+}
+
+Error GetClock_RealTime(uint64_t & curTime)
+{
+    struct timeval tv;
+    int res = gettimeofday(&tv, NULL);
+    if (res != 0)
+    {
+        return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
+    }
+    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
+    {
+        return CHIP_SYSTEM_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    curTime = (tv.tv_sec * UINT64_C(1000000)) + tv.tv_usec;
+    return CHIP_SYSTEM_NO_ERROR;
+}
+
+Error GetClock_RealTimeMS(uint64_t & curTimeMS)
+{
+    struct timeval tv;
+    int res = gettimeofday(&tv, NULL);
+    if (res != 0)
+    {
+        return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
+    }
+    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
+    {
+        return CHIP_SYSTEM_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    curTimeMS = (tv.tv_sec * UINT64_C(1000)) + (tv.tv_usec / 1000);
+    return CHIP_SYSTEM_NO_ERROR;
+}
+
+Error SetClock_RealTime(uint64_t newCurTime)
+{
+    struct timeval tv;
+    tv.tv_sec  = static_cast<time_t>(newCurTime / UINT64_C(1000000));
+    tv.tv_usec = static_cast<long>(newCurTime % UINT64_C(1000000));
+    int res    = settimeofday(&tv, NULL);
+    if (res != 0)
+    {
+        return CHIP_SYSTEM_ERROR_UNEXPECTED_STATE;
+    }
+#if CHIP_PROGRESS_LOGGING
+    {
+        uint16_t year;
+        uint8_t month, dayOfMonth, hour, minute, second;
+        SecondsSinceEpochToCalendarTime(tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
+        ChipLogProgress(DeviceLayer,
+                        "Real time clock set to %ld (%04" PRId16 "/%02" PRId8 "/%02" PRId8 " %02" PRId8 ":%02" PRId8 ":%02" PRId8
+                        " UTC)",
+                        tv.tv_sec, year, month, dayOfMonth, hour, minute, second);
+    }
+#endif // CHIP_PROGRESS_LOGGING
+    return CHIP_SYSTEM_NO_ERROR;
+}
+
+} // namespace Layer
+} // namespace Platform
+} // namespace System
+} // namespace chip

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -35,43 +35,30 @@ namespace System {
 namespace Platform {
 namespace Layer {
 
-/**
- * Platform-specific function for getting monotonic system time in microseconds.
- *
- * @returns Elapsed time in microseconds since an arbitrary, platform-defined epoch.
- */
+// Platform-specific function for getting monotonic system time in microseconds.
+// Returns elapsed time in microseconds since an arbitrary, platform-defined epoch.
 uint64_t GetClock_Monotonic()
 {
     return rtos::Kernel::get_ms_count() * UINT64_C(1000);
 }
 
-/**
- * Platform-specific function for getting monotonic system time in milliseconds.
- *
- * @returns Elapsed time in milliseconds since an arbitrary, platform-defined epoch.
- */
+// Platform-specific function for getting monotonic system time in milliseconds.
+// Return elapsed time in milliseconds since an arbitrary, platform-defined epoch.
 uint64_t GetClock_MonotonicMS()
 {
     return rtos::Kernel::get_ms_count();
 }
 
-/**
- * Platform-specific function for getting high-resolution monotonic system time in microseconds.
- *
- * @returns Elapsed time in microseconds since an arbitrary, platform-defined epoch.
- */
+// Platform-specific function for getting high-resolution monotonic system time in microseconds.
+// Returns elapsed time in microseconds since an arbitrary, platform-defined epoch.
 uint64_t GetClock_MonotonicHiRes()
 {
     return GetClock_Monotonic();
 }
 
-/**
- * Platform-specific function for getting the current real (civil) time in microsecond Unix time
- * format.
- *
- * @param[out] curTime      The current time, expressed as Unix time scaled to microseconds.
- * @returns                 CHIP_SYSTEM_NO_ERROR if the method succeeded.
- */
+// Platform-specific function for getting the current real (civil) time in microsecond Unix time format,
+// where |curTime| argument is the current time, expressed as Unix time scaled to microseconds.
+// Returns CHIP_SYSTEM_NO_ERROR if the method succeeded.
 Error GetClock_RealTime(uint64_t & curTime)
 {
     struct timeval tv;
@@ -88,13 +75,9 @@ Error GetClock_RealTime(uint64_t & curTime)
     return CHIP_SYSTEM_NO_ERROR;
 }
 
-/**
- * Platform-specific function for getting the current real (civil) time in millisecond Unix time
- * format.
- *
- * @param[out] curTimeMS    The current time, expressed as Unix time scaled to milliseconds.
- * @returns                 CHIP_SYSTEM_NO_ERROR if the method succeeded.
- */
+// Platform-specific function for getting the current real (civil) time in millisecond Unix time
+// where |curTimeMS| is the current time, expressed as Unix time scaled to milliseconds.
+// Returns CHIP_SYSTEM_NO_ERROR if the method succeeded.
 Error GetClock_RealTimeMS(uint64_t & curTimeMS)
 {
     struct timeval tv;
@@ -111,12 +94,9 @@ Error GetClock_RealTimeMS(uint64_t & curTimeMS)
     return CHIP_SYSTEM_NO_ERROR;
 }
 
-/**
- * Platform-specific function for setting the current real (civil) time.
- *
- * @param[out] newCurTime   The new current time, expressed as Unix time scaled to microseconds.
- * @returns                 CHIP_SYSTEM_NO_ERROR if the method succeeded.
- */
+// Platform-specific function for setting the current real (civil) time
+// where |newCurTime| is the  new current time, expressed as Unix time scaled to microseconds.
+// Returns CHIP_SYSTEM_NO_ERROR if the method succeeded.
 Error SetClock_RealTime(uint64_t newCurTime)
 {
     struct timeval tv;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Missing SystemTimeSupport.cpp implementation.



 #### Summary of Changes
Add SystemTimeSupport.cpp to src/platform/mbed/
Update src/platform/BUILD.gn 

 Fixes #26