### PR TITLE
Platform manager implementation

### DIFF
--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -121,6 +121,15 @@ list(APPEND CHIP_CFLAGS_C ${CMAKE_C_FLAGS_INIT})
 mbed_get_lang_compile_flags(CHIP_CFLAGS_CC mbed-core CXX)
 list(APPEND CHIP_CFLAGS_CC ${CMAKE_CXX_FLAGS_INIT})
 
+# Add support for Mbed event 
+mbed_get_target_common_compile_flags(CHIP_MBEDEVENTS_CFLAGS mbed-events)
+list(APPEND CHIP_CFLAGS ${CHIP_MBEDEVENTS_CFLAGS})
+
+# Add support for Mbed rtos
+mbed_get_target_common_compile_flags(CHIP_MBEDRTOS_CFLAGS mbed-rtos)
+list(APPEND CHIP_CFLAGS ${CHIP_MBEDRTOS_CFLAGS})
+
+
 if (CONFIG_CHIP_WITH_EXTERNAL_MBEDTLS)
     mbed_get_target_common_compile_flags(CHIP_MBEDTLS_CFLAGS mbed-mbedtls)
     list(APPEND CHIP_CFLAGS ${CHIP_MBEDTLS_CFLAGS})
@@ -184,7 +193,7 @@ elseif (BOARD STREQUAL "native_posix_64")
     chip_gn_arg_string("target_cpu" "x64")
 endif()
 
-file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/args.gn CONTENT ${CHIP_GN_ARGS})
+# file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/args.gn CONTENT ${CHIP_GN_ARGS})
 
 # ==============================================================================
 # Define 'chip-gn' target that builds CHIP library(ies) with GN build system

--- a/config/mbed/CMakeLists.txt
+++ b/config/mbed/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif (BOARD STREQUAL "native_posix_64")
     chip_gn_arg_string("target_cpu" "x64")
 endif()
 
-# file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/args.gn CONTENT ${CHIP_GN_ARGS})
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/args.gn CONTENT ${CHIP_GN_ARGS})
 
 # ==============================================================================
 # Define 'chip-gn' target that builds CHIP library(ies) with GN build system

--- a/examples/shell/mbed/CMakeLists.txt
+++ b/examples/shell/mbed/CMakeLists.txt
@@ -43,7 +43,7 @@ mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
-target_link_libraries(${APP_TARGET} mbed-os mbed-core mbed-events mbed-rtos chip)
+target_link_libraries(${APP_TARGET} mbed-os mbed-events chip)
 
 mbed_set_post_build(${APP_TARGET})
 

--- a/examples/shell/mbed/CMakeLists.txt
+++ b/examples/shell/mbed/CMakeLists.txt
@@ -43,7 +43,7 @@ mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
-target_link_libraries(${APP_TARGET} mbed-os chip)
+target_link_libraries(${APP_TARGET} mbed-os mbed-core mbed-events mbed-rtos chip)
 
 mbed_set_post_build(${APP_TARGET})
 

--- a/src/lwip/mbed/sys_arch.c
+++ b/src/lwip/mbed/sys_arch.c
@@ -572,7 +572,31 @@ void sys_sem_free(struct sys_sem ** sem)
         sys_sem_free_internal(*sem);
     }
 }
+
+#else 
+
+u32_t sys_arch_sem_wait(sys_sem_t * sem, u32_t timeout)
+{
+    return 0;
+}
+
+void sys_sem_signal(struct sys_sem ** s)
+{
+
+}
+
+err_t sys_mbox_trypost(struct sys_mbox ** mb, void * msg)
+{
+    return ERR_OK;
+}
+
+void sys_mbox_post(struct sys_mbox ** mb, void * msg)
+{
+    
+}
+
 #endif /* !NO_SYS */
+
 /*-----------------------------------------------------------------------------------*/
 u32_t sys_now(void)
 {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -536,7 +536,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       sources += [
         "mbed/ConfigurationManagerImpl.cpp",
         "mbed/SystemTimeSupport.cpp",
-        "mbed/MbedConfig.cpp"
+        "mbed/MbedConfig.cpp",
+        "mbed/PlatformManagerImpl.cpp"
       ]
     }
 

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -37,5 +37,10 @@ using namespace ::chip::DeviceLayer::Internal;
  */
 ConfigurationManagerImpl ConfigurationManagerImpl::sInstance;
 
+CHIP_ERROR ConfigurationManagerImpl::_Init()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -8,7 +8,15 @@ namespace DeviceLayer {
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    // Members are initialized by the stack
+    // TODO: understand if they should be dynamicaly allocated or not.
+
+    // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
+    auto err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
+    SuccessOrExit(err);
+
+exit:
+    return err;
 }
 
 void PlatformManagerImpl::_LockChipStack()

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -1,3 +1,5 @@
+#include <new>
+
 #include "platform/internal/CHIPDeviceLayerInternal.h"
 
 #include <platform/PlatformManager.h>
@@ -6,14 +8,40 @@
 namespace chip {
 namespace DeviceLayer {
 
+// TODO: Event and timer processing is not efficient from a memory perspective.
+// Both occupy at least 24 bytes when only 4 bytes is required.
+// An optimized designed could use a separate circular buffer to store events
+// and register a single mbed event in the event queue to process all of them.
+// A similar design can be used for timers.
+
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     // Members are initialized by the stack
-    // TODO: understand if they should be dynamicaly allocated or not.
+    if (!mInitialized)
+    {
+        // reinitialize a new thread if it was terminated earlier
+        mLoopTask.~Thread();
+        new (&mLoopTask) rtos::Thread(osPriorityNormal, CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE,
+                                      /* memory provided */ nullptr, CHIP_DEVICE_CONFIG_CHIP_TASK_NAME);
+
+        // Reinitialize the EventQueue
+        mQueue.~EventQueue();
+        new (&mQueue) events::EventQueue(event_size * CHIP_DEVICE_CONFIG_MAX_EVENT_QUEUE_SIZE);
+
+        // Reinitialize the Mutex
+        mChipStackMutex.~Mutex();
+        new (&mChipStackMutex) rtos::Mutex();
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Trying to reinitialize the stack");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
 
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     auto err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
     SuccessOrExit(err);
+    mInitialized = true;
 
 exit:
     return err;
@@ -33,23 +61,111 @@ void PlatformManagerImpl::_UnlockChipStack()
     mChipStackMutex.unlock();
 }
 
-void PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event) {}
+void PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event)
+{
+    auto handle = mQueue.call([event, this] {
+        LockChipStack();
+        DispatchEvent(event);
+        UnlockChipStack();
+    });
 
-void PlatformManagerImpl::_RunEventLoop() {}
+    if (!handle)
+    {
+        ChipLogError(DeviceLayer, "Error posting event: Not enough memory");
+    }
+}
+
+void PlatformManagerImpl::_RunEventLoop()
+{
+    // Note: no reason to lock the chip task here, it is locked by the
+    // event and timer callback
+    mQueue.dispatch_forever();
+}
 
 CHIP_ERROR PlatformManagerImpl::_StartEventLoopTask()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    // This function start the Thread that run the chip event loop.
+    // If no threads are needed, the application can directly call RunEventLoop.
+    auto error = mLoopTask.start([this] {
+        ChipLogDetail(DeviceLayer, "CHIP task running");
+        RunEventLoop();
+    });
+
+    CHIP_ERROR err = TranslateOsStatus(error);
+    SuccessOrExit(err);
+
+exit:
+    return err;
 }
 
 CHIP_ERROR PlatformManagerImpl::_StartChipTimer(int64_t durationMS)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int event      = 0;
+
+    VerifyOrExit(mInitialized == true, err = CHIP_ERROR_INCORRECT_STATE);
+
+    event = mQueue.call_in(std::chrono::milliseconds(durationMS), [this] {
+        LockChipStack();
+        auto err = SystemLayer.HandlePlatformTimer();
+        if (err != CHIP_SYSTEM_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Error handling CHIP timers: %s", ErrorStr(err));
+        }
+        UnlockChipStack();
+    });
+
+    VerifyOrExit(event != 0, err = CHIP_ERROR_NO_MEMORY);
+
+exit:
+    return err;
 }
 
 CHIP_ERROR PlatformManagerImpl::_Shutdown()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    LockChipStack();
+
+    // If running, break out of the loop
+    if (IsLoopActive())
+    {
+        mQueue.break_dispatch();
+        mLoopTask.join();
+    }
+
+    // Note: we leave the event queue as is. It will be reinitialized in Init()
+    mInitialized = false;
+    UnlockChipStack();
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PlatformManagerImpl::TranslateOsStatus(osStatus error)
+{
+    switch (error)
+    {
+    case osErrorNoMemory:
+        return CHIP_ERROR_NO_MEMORY;
+
+    case osOK:
+        return CHIP_NO_ERROR;
+
+    default:
+        return CHIP_ERROR_INTERNAL;
+    }
+}
+
+bool PlatformManagerImpl::IsLoopActive()
+{
+    switch (mLoopTask.get_state())
+    {
+    case rtos::Thread::Inactive:
+    case rtos::Thread::Ready:
+    case rtos::Thread::Deleted:
+        return false;
+
+    default:
+        return true;
+    }
 }
 
 // ===== Members for internal use by the following friends.

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -1,4 +1,4 @@
-#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include "platform/internal/CHIPDeviceLayerInternal.h"
 
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl.cpp>
@@ -8,16 +8,22 @@ namespace DeviceLayer {
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
-    return 0;
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-void PlatformManagerImpl::_LockChipStack() {}
+void PlatformManagerImpl::_LockChipStack()
+{
+    mChipStackMutex.lock();
+}
 
 bool PlatformManagerImpl::_TryLockChipStack()
 {
-    return true;
+    return mChipStackMutex.trylock();
 }
-void PlatformManagerImpl::_UnlockChipStack() {}
+void PlatformManagerImpl::_UnlockChipStack()
+{
+    mChipStackMutex.unlock();
+}
 
 void PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event) {}
 
@@ -25,17 +31,17 @@ void PlatformManagerImpl::_RunEventLoop() {}
 
 CHIP_ERROR PlatformManagerImpl::_StartEventLoopTask()
 {
-    return 0;
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 CHIP_ERROR PlatformManagerImpl::_StartChipTimer(int64_t durationMS)
 {
-    return 0;
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 CHIP_ERROR PlatformManagerImpl::_Shutdown()
 {
-    return 0;
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 // ===== Members for internal use by the following friends.

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -1,0 +1,46 @@
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <platform/PlatformManager.h>
+#include <platform/internal/GenericPlatformManagerImpl.cpp>
+
+namespace chip {
+namespace DeviceLayer {
+
+CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
+{
+    return 0;
+}
+
+void PlatformManagerImpl::_LockChipStack() {}
+
+bool PlatformManagerImpl::_TryLockChipStack()
+{
+    return true;
+}
+void PlatformManagerImpl::_UnlockChipStack() {}
+
+void PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event) {}
+
+void PlatformManagerImpl::_RunEventLoop() {}
+
+CHIP_ERROR PlatformManagerImpl::_StartEventLoopTask()
+{
+    return 0;
+}
+
+CHIP_ERROR PlatformManagerImpl::_StartChipTimer(int64_t durationMS)
+{
+    return 0;
+}
+
+CHIP_ERROR PlatformManagerImpl::_Shutdown()
+{
+    return 0;
+}
+
+// ===== Members for internal use by the following friends.
+
+PlatformManagerImpl PlatformManagerImpl::sInstance;
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/mbed/PlatformManagerImpl.h
+++ b/src/platform/mbed/PlatformManagerImpl.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "rtos/Mutex.h"
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
@@ -68,6 +69,9 @@ private:
     friend class Internal::BLEManagerImpl;
 
     static PlatformManagerImpl sInstance;
+
+    // ===== Members for internal use.
+    rtos::Mutex mChipStackMutex;
 };
 
 /**

--- a/src/platform/mbed/PlatformManagerImpl.h
+++ b/src/platform/mbed/PlatformManagerImpl.h
@@ -22,7 +22,9 @@
 
 #pragma once
 
+#include "events/EventQueue.h"
 #include "rtos/Mutex.h"
+#include "rtos/Thread.h"
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
@@ -71,7 +73,15 @@ private:
     static PlatformManagerImpl sInstance;
 
     // ===== Members for internal use.
+    static CHIP_ERROR TranslateOsStatus(osStatus status);
+    bool IsLoopActive();
+
+    bool mInitialized = false;
+    rtos::Thread mLoopTask{ osPriorityNormal, CHIP_DEVICE_CONFIG_CHIP_TASK_STACK_SIZE,
+                            /* memory provided */ nullptr, CHIP_DEVICE_CONFIG_CHIP_TASK_NAME };
     rtos::Mutex mChipStackMutex;
+    static const size_t event_size = EVENTS_EVENT_SIZE + sizeof(void *) + sizeof(ChipDeviceEvent *);
+    events::EventQueue mQueue      = { event_size * CHIP_DEVICE_CONFIG_MAX_EVENT_QUEUE_SIZE };
 };
 
 /**

--- a/src/platform/mbed/PlatformManagerImpl.h
+++ b/src/platform/mbed/PlatformManagerImpl.h
@@ -51,15 +51,15 @@ public:
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
-    CHIP_ERROR _InitChipStack(void) { return 0; }
-    void _LockChipStack() {}
-    bool _TryLockChipStack() { return true; }
-    void _UnlockChipStack() {}
-    void _PostEvent(const ChipDeviceEvent * event) {}
-    void _RunEventLoop() {}
-    CHIP_ERROR _StartEventLoopTask() { return 0; }
-    CHIP_ERROR _StartChipTimer(int64_t durationMS) { return 0; }
-    CHIP_ERROR _Shutdown() { return 0; }
+    CHIP_ERROR _InitChipStack(void);
+    void _LockChipStack();
+    bool _TryLockChipStack();
+    void _UnlockChipStack();
+    void _PostEvent(const ChipDeviceEvent * event);
+    void _RunEventLoop();
+    CHIP_ERROR _StartEventLoopTask();
+    CHIP_ERROR _StartChipTimer(int64_t durationMS);
+    CHIP_ERROR _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -34,7 +34,7 @@ declare_args() {
 }
 
 if (chip_system_config_locking == "") {
-  if (current_os != "freertos") {
+  if (current_os != "freertos" && current_os != "mbed") {
     chip_system_config_locking = "posix"
   } else {
     chip_system_config_locking = "none"


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
 
CHIP needs platform support to post, execute events and lock the stack. 


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Implement mbed version of PlatformManagerImpl.
Resolves #24, resolves #25 (No extra work required at this point, default implementation is good enough).
