### PR TITLE
Add 'date' command to mbed shell example.

### DIFF
--- a/examples/shell/mbed/CMakeLists.txt
+++ b/examples/shell/mbed/CMakeLists.txt
@@ -22,7 +22,8 @@ add_subdirectory(${MBED_PATH} ./mbed_build)
 add_executable(${APP_TARGET})
 
 target_include_directories(${APP_TARGET} PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR})
+                           ${CMAKE_CURRENT_SOURCE_DIR}
+                           ${APP_ROOT}/shell_common/include)
 
 target_sources(${APP_TARGET} PRIVATE
     ${APP_ROOT}/shell_common/cmd_base64.cpp

--- a/examples/shell/mbed/CMakeLists.txt
+++ b/examples/shell/mbed/CMakeLists.txt
@@ -22,8 +22,7 @@ add_subdirectory(${MBED_PATH} ./mbed_build)
 add_executable(${APP_TARGET})
 
 target_include_directories(${APP_TARGET} PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR}
-                           ${APP_ROOT}/shell_common/include)
+                           ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(${APP_TARGET} PRIVATE
     ${APP_ROOT}/shell_common/cmd_base64.cpp
@@ -31,8 +30,9 @@ target_sources(${APP_TARGET} PRIVATE
     ${APP_ROOT}/shell_common/cmd_misc.cpp
     ${APP_ROOT}/shell_common/cmd_otcli.cpp
     ${APP_ROOT}/shell_common/cmd_btp.cpp
-    ${APP_ROOT}/standalone/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmd_mbed_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/arch.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
 )
 
 add_subdirectory(${CHIP_ROOT}/config/mbed ./chip_build)

--- a/examples/shell/mbed/ChipShellCollection.h
+++ b/examples/shell/mbed/ChipShellCollection.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/examples/shell/mbed/ChipShellCollection.h
+++ b/examples/shell/mbed/ChipShellCollection.h
@@ -1,0 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+extern "C" {
+// A list of shell commands provided by ChipShell
+void cmd_base64_init(void);
+void cmd_btp_init(void);
+void cmd_device_init(void);
+void cmd_misc_init(void);
+void cmd_otcli_init(void);
+void cmd_mbed_utils_init(void);
+}

--- a/examples/shell/mbed/ChipShellMbedCollection.h
+++ b/examples/shell/mbed/ChipShellMbedCollection.h
@@ -18,11 +18,6 @@
 #pragma once
 
 extern "C" {
-// A list of shell commands provided by ChipShell
-void cmd_base64_init(void);
-void cmd_btp_init(void);
-void cmd_device_init(void);
-void cmd_misc_init(void);
-void cmd_otcli_init(void);
+// A list of shell commands provided by Mbed-OS port.
 void cmd_mbed_utils_init(void);
 }

--- a/examples/shell/mbed/cmd_mbed_utils.cpp
+++ b/examples/shell/mbed/cmd_mbed_utils.cpp
@@ -25,7 +25,7 @@
 #include <inttypes.h>
 #include <stdarg.h>
 
-#include <ChipShellCollection.h>
+#include "ChipShellMbedCollection.h"
 
 using namespace chip;
 using namespace chip::Shell;
@@ -89,20 +89,20 @@ int cmd_date_set(int argc, char ** argv)
     ret = sscanf(argv[0], "%4" SCNu16 "-%2" SCNu8 "-%2" SCNu8, &year, &month, &dayOfMonth);
     if (3 != ret)
     {
-        streamer_printf(sout, "ERROR: Date is in wrong format!\r\n");
+        streamer_printf(sout, "ERROR: Date is in wrong format! Please use 'YYYY-MM-DD HH:MM:SS' format.\r\n");
         ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
     }
 
     ret = sscanf(argv[1], "%2" SCNu8 ":%2" SCNu8 ":%2" SCNu8, &hour, &minute, &seconds);
     if (3 != ret)
     {
-        streamer_printf(sout, "ERROR: Time is in wrong format!\r\n");
+        streamer_printf(sout, "ERROR: Time is in wrong format! Please use 'YYYY-MM-DD HH:MM:SS' format.\r\n");
         ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
     }
 
     if (!CalendarTimeToSecondsSinceEpoch(year, month, dayOfMonth, hour, minute, seconds, newCurrTime))
     {
-        streamer_printf(sout, "ERROR: Wrond date and/or time value\r\n");
+        streamer_printf(sout, "ERROR: Wrond date and/or time values\r\n");
         ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
     }
 

--- a/examples/shell/mbed/cmd_mbed_utils.cpp
+++ b/examples/shell/mbed/cmd_mbed_utils.cpp
@@ -64,7 +64,7 @@ int cmd_date_dispatch(int argc, char ** argv)
         }
 
         SecondsSinceEpochToCalendarTime(currTimeMS / 1000, year, month, dayOfMonth, hour, minute, second);
-        streamer_printf(sout, "%04" PRIu16 "-%02" PRIu8 "-%02" PRIu8 " %02" PRIu8 ":%02" PRIu8 ":%02" PRIu16 "\n\r", year, month,
+        streamer_printf(sout, "%04" PRIu16 "-%02" PRIu8 "-%02" PRIu8 " %02" PRIu8 ":%02" PRIu8 ":%02" PRIu8 "\n\r", year, month,
                         dayOfMonth, hour, minute, second);
         return CHIP_NO_ERROR;
     }
@@ -86,14 +86,14 @@ int cmd_date_set(int argc, char ** argv)
 
     VerifyOrExit(argc == 2, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    ret = sscanf(argv[0], "%" SCNu16 "-%02" SCNu8 "-%02" SCNu8, &year, &month, &dayOfMonth);
+    ret = sscanf(argv[0], "%4" SCNu16 "-%2" SCNu8 "-%2" SCNu8, &year, &month, &dayOfMonth);
     if (3 != ret)
     {
         streamer_printf(sout, "ERROR: Date is in wrong format!\r\n");
         ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
     }
 
-    ret = sscanf(argv[1], "%02" SCNu8 ":%02" SCNu8 ":%02" SCNu8, &hour, &minute, &seconds);
+    ret = sscanf(argv[1], "%2" SCNu8 ":%2" SCNu8 ":%2" SCNu8, &hour, &minute, &seconds);
     if (3 != ret)
     {
         streamer_printf(sout, "ERROR: Time is in wrong format!\r\n");

--- a/examples/shell/mbed/cmd_mbed_utils.cpp
+++ b/examples/shell/mbed/cmd_mbed_utils.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/examples/shell/mbed/cmd_mbed_utils.cpp
+++ b/examples/shell/mbed/cmd_mbed_utils.cpp
@@ -1,0 +1,124 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/shell/shell.h>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/support/CHIPArgParser.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/TimeUtils.h>
+
+#include <inttypes.h>
+#include <stdarg.h>
+
+#include <ChipShellCollection.h>
+
+using namespace chip;
+using namespace chip::Shell;
+using namespace chip::System;
+
+static chip::Shell::Shell sShellDateSubcommands;
+
+int cmd_date_help_iterator(shell_command_t * command, void * arg)
+{
+    streamer_printf(streamer_get(), "  %-15s %s\n\r", command->cmd_name, command->cmd_help);
+    return 0;
+}
+
+int cmd_date_help(int argc, char ** argv)
+{
+    sShellDateSubcommands.ForEachCommand(cmd_date_help_iterator, nullptr);
+    return 0;
+}
+
+int cmd_date_dispatch(int argc, char ** argv)
+{
+    uint16_t year;
+    uint8_t month, dayOfMonth;
+    uint8_t hour, minute, second;
+
+    uint64_t currTimeMS = 0;
+
+    streamer_t * sout = streamer_get();
+
+    if (0 == argc)
+    {
+        if (Layer::GetClock_RealTimeMS(currTimeMS) != CHIP_SYSTEM_NO_ERROR)
+        {
+            streamer_printf(sout, "ERROR: Date/Time was not set\r\n");
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+
+        SecondsSinceEpochToCalendarTime(currTimeMS / 1000, year, month, dayOfMonth, hour, minute, second);
+        streamer_printf(sout, "%04" PRIu16 "-%02" PRIu8 "-%02" PRIu8 " %02" PRIu8 ":%02" PRIu8 ":%02" PRIu16 "\n\r", year, month,
+                        dayOfMonth, hour, minute, second);
+        return CHIP_NO_ERROR;
+    }
+
+    return sShellDateSubcommands.ExecCommand(argc, argv);
+}
+
+int cmd_date_set(int argc, char ** argv)
+{
+    uint16_t year;
+    uint8_t month, dayOfMonth;
+    uint8_t hour, minute, seconds;
+
+    uint32_t newCurrTime = 0;
+    streamer_t * sout    = streamer_get();
+
+    int ret          = 0;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    VerifyOrExit(argc == 2, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    ret = sscanf(argv[0], "%" SCNu16 "-%02" SCNu8 "-%02" SCNu8, &year, &month, &dayOfMonth);
+    if (3 != ret)
+    {
+        streamer_printf(sout, "ERROR: Date is in wrong format!\r\n");
+        ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
+    }
+
+    ret = sscanf(argv[1], "%02" SCNu8 ":%02" SCNu8 ":%02" SCNu8, &hour, &minute, &seconds);
+    if (3 != ret)
+    {
+        streamer_printf(sout, "ERROR: Time is in wrong format!\r\n");
+        ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
+    }
+
+    if (!CalendarTimeToSecondsSinceEpoch(year, month, dayOfMonth, hour, minute, seconds, newCurrTime))
+    {
+        streamer_printf(sout, "ERROR: Wrond date and/or time value\r\n");
+        ExitNow(error = CHIP_ERROR_INVALID_ARGUMENT;);
+    }
+
+    error = Layer::SetClock_RealTime(static_cast<uint64_t>(newCurrTime) * UINT64_C(1000000));
+
+exit:
+    return error;
+}
+
+static const shell_command_t cmds_date_root = { &cmd_date_dispatch, "date", "Display the current time, or set the system date." };
+
+static const shell_command_t cmds_date[] = { { &cmd_date_set, "set", "Set date/time using 'YYYY-MM-DD HH:MM:SS' format" },
+                                             { &cmd_date_help, "help", "Display help for each subcommand" } };
+
+void cmd_mbed_utils_init()
+{
+    sShellDateSubcommands.RegisterCommands(cmds_date, ArraySize(cmds_date));
+    shell_register(&cmds_date_root, 1);
+}

--- a/examples/shell/mbed/main.cpp
+++ b/examples/shell/mbed/main.cpp
@@ -24,6 +24,7 @@
 #include <lib/support/RandUtils.h>
 #include <support/logging/CHIPLogging.h>
 
+#include "ChipShellMbedCollection.h"
 #include <ChipShellCollection.h>
 
 using namespace chip;

--- a/examples/shell/mbed/main.cpp
+++ b/examples/shell/mbed/main.cpp
@@ -1,0 +1,52 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/shell/shell.h>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/support/Base64.h>
+#include <lib/support/CHIPArgParser.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/RandUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+#include <ChipShellCollection.h>
+
+using namespace chip;
+using namespace chip::Shell;
+
+int main()
+{
+    // Initialize the default streamer that was linked.
+    const int rc = streamer_init(streamer_get());
+
+    if (rc != 0)
+    {
+        ChipLogError(Shell, "Streamer initialization failed: %d", rc);
+        return rc;
+    }
+
+    cmd_misc_init();
+    cmd_base64_init();
+    cmd_device_init();
+    cmd_btp_init();
+    cmd_otcli_init();
+    cmd_mbed_utils_init();
+
+    shell_task(nullptr);
+    return 0;
+}


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We need some way to verify SystemTimeSupport implementation for Mbed-OS.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Adding |date| command to shell example which may be used to display and set system date and time.
Update CMakeList.txt.

Usage example:
```
date set YYYY-MM-DD HH:MM:SS
date
```


<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

Fixes #26
Preceding PR: #45
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
