### PR TITLE
Wifi initial draft for mbed

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -534,7 +534,12 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       }
     } else if (chip_device_platform == "mbed") {
       sources += [
+        "mbed/PlatformManagerImpl.cpp",
         "mbed/ConfigurationManagerImpl.cpp",
+        "mbed/ConnectivityManagerImpl.cpp",
+        "mbed/ConnectivityManagerImpl.h",
+        "mbed/DeviceNetworkProvisioningDelegateImpl.cpp",
+        "mbed/DeviceNetworkProvisioningDelegateImpl.h",
         "mbed/MbedConfig.cpp"
       ]
     }

--- a/src/platform/mbed/ConnectivityManagerImpl.cpp
+++ b/src/platform/mbed/ConnectivityManagerImpl.cpp
@@ -1,0 +1,350 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/* this file behaves like a config.h, comes first */
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <platform/ConnectivityManager.h>
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#include <platform/internal/GenericConnectivityManagerImpl_BLE.cpp>
+#endif
+#include <platform/internal/GenericConnectivityManagerImpl_WiFi.cpp>
+
+#include <platform/internal/BLEManager.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+#include <type_traits>
+
+#if !CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+//#error "WiFi Station support must be enabled when building for mbed"
+#endif
+
+#if !CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
+//#error "WiFi AP support must be enabled when building for mbed"
+#endif
+
+using namespace ::chip;
+using namespace ::chip::Inet;
+using namespace ::chip::System;
+using namespace ::chip::TLV;
+
+namespace chip {
+namespace DeviceLayer {
+
+ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
+
+ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode(void)
+{
+    if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
+    {
+
+        mWiFiStationMode = kWiFiStationMode_Enabled;
+        //  : kWiFiStationMode_Disabled;
+    }
+    return mWiFiStationMode;
+}
+
+bool ConnectivityManagerImpl::_IsWiFiStationEnabled(void)
+{
+    return GetWiFiStationMode() == kWiFiStationMode_Enabled;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(WiFiStationMode val)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(val != kWiFiStationMode_NotSupported, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    if (mWiFiStationMode != val)
+    {
+        ChipLogProgress(DeviceLayer, "WiFi station mode change: %s -> %s", WiFiStationModeToStr(mWiFiStationMode),
+                        WiFiStationModeToStr(val));
+    }
+
+    mWiFiStationMode = val;
+
+exit:
+    return err;
+}
+bool ConnectivityManagerImpl::_IsWiFiStationConnected(void)
+{
+    return mWiFiStationState == kWiFiStationState_Connected;
+}
+bool ConnectivityManagerImpl::_IsWiFiStationProvisioned(void)
+{
+    return false;
+}
+
+void ConnectivityManagerImpl::_ClearWiFiStationProvision(void) {}
+
+CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    return err;
+}
+
+#define WIFI_BAND_2_4GHZ 2400
+#define WIFI_BAND_5_0GHZ 5000
+
+static uint16_t Map2400MHz(const uint8_t inChannel)
+{
+    uint16_t frequency = 0;
+
+    if (inChannel >= 1 && inChannel <= 13)
+    {
+        // Cast is OK because we definitely fit in 16 bits.
+        frequency = static_cast<uint16_t>(2412 + ((inChannel - 1) * 5));
+    }
+    else if (inChannel == 14)
+    {
+        frequency = 2484;
+    }
+
+    return frequency;
+}
+
+static uint16_t Map5000MHz(const uint8_t inChannel)
+{
+    uint16_t frequency = 0;
+
+    switch (inChannel)
+    {
+
+    case 183:
+        frequency = 4915;
+        break;
+    case 184:
+        frequency = 4920;
+        break;
+    case 185:
+        frequency = 4925;
+        break;
+    case 187:
+        frequency = 4935;
+        break;
+    case 188:
+        frequency = 4940;
+        break;
+    case 189:
+        frequency = 4945;
+        break;
+    case 192:
+        frequency = 4960;
+        break;
+    case 196:
+        frequency = 4980;
+        break;
+    case 7:
+        frequency = 5035;
+        break;
+    case 8:
+        frequency = 5040;
+        break;
+    case 9:
+        frequency = 5045;
+        break;
+    case 11:
+        frequency = 5055;
+        break;
+    case 12:
+        frequency = 5060;
+        break;
+    case 16:
+        frequency = 5080;
+        break;
+    case 34:
+        frequency = 5170;
+        break;
+    case 36:
+        frequency = 5180;
+        break;
+    case 38:
+        frequency = 5190;
+        break;
+    case 40:
+        frequency = 5200;
+        break;
+    case 42:
+        frequency = 5210;
+        break;
+    case 44:
+        frequency = 5220;
+        break;
+    case 46:
+        frequency = 5230;
+        break;
+    case 48:
+        frequency = 5240;
+        break;
+    case 52:
+        frequency = 5260;
+        break;
+    case 56:
+        frequency = 5280;
+        break;
+    case 60:
+        frequency = 5300;
+        break;
+    case 64:
+        frequency = 5320;
+        break;
+    case 100:
+        frequency = 5500;
+        break;
+    case 104:
+        frequency = 5520;
+        break;
+    case 108:
+        frequency = 5540;
+        break;
+    case 112:
+        frequency = 5560;
+        break;
+    case 116:
+        frequency = 5580;
+        break;
+    case 120:
+        frequency = 5600;
+        break;
+    case 124:
+        frequency = 5620;
+        break;
+    case 128:
+        frequency = 5640;
+        break;
+    case 132:
+        frequency = 5660;
+        break;
+    case 136:
+        frequency = 5680;
+        break;
+    case 140:
+        frequency = 5700;
+        break;
+    case 149:
+        frequency = 5745;
+        break;
+    case 153:
+        frequency = 5765;
+        break;
+    case 157:
+        frequency = 5785;
+        break;
+    case 161:
+        frequency = 5805;
+        break;
+    case 165:
+        frequency = 5825;
+        break;
+    }
+
+    return frequency;
+}
+
+static uint16_t MapFrequency(const uint16_t inBand, const uint8_t inChannel)
+{
+    uint16_t frequency = 0;
+
+    if (inBand == WIFI_BAND_2_4GHZ)
+    {
+        frequency = Map2400MHz(inChannel);
+    }
+    else if (inBand == WIFI_BAND_5_0GHZ)
+    {
+        frequency = Map5000MHz(inChannel);
+    }
+
+    return frequency;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::GetWifiParams(void)
+{
+
+    return CHIP_NO_ERROR;
+}
+
+// ==================== ConnectivityManager Platform Internal Methods ====================
+
+CHIP_ERROR ConnectivityManagerImpl::_Init()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mWiFiStationMode  = kWiFiStationMode_Disabled;
+    mWiFiStationState = kWiFiStationState_NotConnected;
+
+    mWiFiStationReconnectIntervalMS = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
+    mWiFiAPIdleTimeoutMS            = CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT;
+
+    // TODO Initialize the Chip Addressing and Routing Module.
+
+    return err;
+}
+
+void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event) {}
+
+CHIP_ERROR ConnectivityManagerImpl::WiFiConnect()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::WiFiDisconnect()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, const char * key)
+{
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR ConnectivityManagerImpl::ScanWiFi()
+{
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR ConnectivityManagerImpl::WiFiScanResults()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::OnStationConnected()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Assign an IPv6 link local address to the station interface.
+
+    // Alert other components of the new state.
+    ChipDeviceEvent event;
+    event.Type                          = DeviceEventType::kWiFiConnectivityChange;
+    event.WiFiConnectivityChange.Result = kConnectivity_Established;
+    PlatformMgr().PostEvent(&event);
+}
+
+CHIP_ERROR ConnectivityManagerImpl::OnStationDisconnected()
+{
+    // TODO Invoke WARM to perform actions that occur when the WiFi station interface goes down.
+
+    // Alert other components of the new state.
+    ChipDeviceEvent event;
+    event.Type                          = DeviceEventType::kWiFiConnectivityChange;
+    event.WiFiConnectivityChange.Result = kConnectivity_Lost;
+    PlatformMgr().PostEvent(&event);
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/mbed/DeviceNetworkProvisioningDelegateImpl.cpp
+++ b/src/platform/mbed/DeviceNetworkProvisioningDelegateImpl.cpp
@@ -15,29 +15,27 @@
  *    limitations under the License.
  */
 
-#pragma once
+#include <support/ErrorStr.h>
+#include <support/logging/CHIPLogging.h>
 
-#include <platform/internal/GenericDeviceNetworkProvisioningDelegateImpl.h>
+#include "DeviceNetworkProvisioningDelegateImpl.h"
 
 namespace chip {
 namespace DeviceLayer {
 
-namespace Internal {
-
-template <class ImplClass>
-class GenericDeviceNetworkProvisioningDelegateImpl;
-
-} // namespace Internal
-
-class DeviceNetworkProvisioningDelegateImpl final
-    : public Internal::GenericDeviceNetworkProvisioningDelegateImpl<DeviceNetworkProvisioningDelegateImpl>
+CHIP_ERROR DeviceNetworkProvisioningDelegateImpl::_ProvisionWiFiNetwork(const char * ssid, const char * key)
 {
-private:
-    friend class GenericDeviceNetworkProvisioningDelegateImpl<DeviceNetworkProvisioningDelegateImpl>;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    CHIP_ERROR _ProvisionWiFiNetwork(const char * ssid, const char * passwd);
-    CHIP_ERROR _ProvisionThreadNetwork(DeviceLayer::Internal::DeviceNetworkInfo & threadData) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-};
+    ChipLogProgress(NetworkProvisioning, "MbedNetworkProvisioningDelegate: SSID: %s", ssid);
+    err = ConnectivityMgrImpl().ProvisionWiFiNetwork(ssid, key);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %s", chip::ErrorStr(err));
+    }
+
+    return err;
+}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -1,6 +1,8 @@
 /*
  *
  *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,29 +17,34 @@
  *    limitations under the License.
  */
 
-#pragma once
+/**
+ *    @file
+ *          Provides an implementation of the PlatformManager object
+ *          for the ESP32 platform.
+ */
+/* this file behaves like a config.h, comes first */
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <platform/internal/GenericDeviceNetworkProvisioningDelegateImpl.h>
+#include <platform/PlatformManager.h>
 
 namespace chip {
 namespace DeviceLayer {
 
 namespace Internal {
+extern CHIP_ERROR InitLwIPCoreLock(void);
+}
 
-template <class ImplClass>
-class GenericDeviceNetworkProvisioningDelegateImpl;
+PlatformManagerImpl PlatformManagerImpl::sInstance;
 
-} // namespace Internal
-
-class DeviceNetworkProvisioningDelegateImpl final
-    : public Internal::GenericDeviceNetworkProvisioningDelegateImpl<DeviceNetworkProvisioningDelegateImpl>
+CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
-private:
-    friend class GenericDeviceNetworkProvisioningDelegateImpl<DeviceNetworkProvisioningDelegateImpl>;
+    CHIP_ERROR err;
 
-    CHIP_ERROR _ProvisionWiFiNetwork(const char * ssid, const char * passwd);
-    CHIP_ERROR _ProvisionThreadNetwork(DeviceLayer::Internal::DeviceNetworkInfo & threadData) { return CHIP_ERROR_NOT_IMPLEMENTED; }
-};
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/PlatformManagerImpl.h
+++ b/src/platform/mbed/PlatformManagerImpl.h
@@ -51,7 +51,7 @@ public:
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
-    CHIP_ERROR _InitChipStack(void) { return 0; }
+    CHIP_ERROR _InitChipStack(void);
     void _LockChipStack() {}
     bool _TryLockChipStack() { return true; }
     void _UnlockChipStack() {}
@@ -77,6 +77,17 @@ private:
  * that are common to all platforms.
  */
 inline PlatformManager & PlatformMgr(void)
+{
+    return PlatformManagerImpl::sInstance;
+}
+
+/**
+ * Returns the public interface of the PlatformManager singleton object.
+ *
+ * chip applications should use this to access features of the PlatformManager object
+ * that are specific to mbed based platforms.
+ */
+inline PlatformManagerImpl & PlatformMgrImpl(void)
 {
     return PlatformManagerImpl::sInstance;
 }


### PR DESCRIPTION
 Problem

Initial proposal Connectivity Manager for basic wifi interface actions

NetworkProvisioningServerImpl class is currently not used due to incomplete and faulty implementation
Wifi scan and discovered acces points list are currently handled inside ConnectivityManagerImpl.

This  PR  is far from desired state but can builld sucesfully on discovery target