### PR TITLE
Mbed: Copy the event into the event queue instead of using ptr.

### DIFF
--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -61,11 +61,11 @@ void PlatformManagerImpl::_UnlockChipStack()
     mChipStackMutex.unlock();
 }
 
-void PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event)
+void PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * eventPtr)
 {
-    auto handle = mQueue.call([event, this] {
+    auto handle = mQueue.call([event = *eventPtr, this] {
         LockChipStack();
-        DispatchEvent(event);
+        DispatchEvent(&event);
         UnlockChipStack();
     });
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The event queue stop execution with BLE

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Turns out that the platform doesn't allocate and release events. Some events are allocated on the stack and end up corrupted when executed by the event queue. 
Except on Linux, no copy of the events is made on Zephyr or FreeRTOS platform; it is a mystery how it can even work. 

Fixes #80



<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
