### PR TITLE
Add vscode tasks for flashing and debugging Mbed Shell examples

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,6 +35,9 @@ RUN apt-get -fy install git vim emacs sudo \
     wget curl telnet \
     docker.io \
     iputils-ping net-tools
+
+RUN python3 -m pip install pyocd pyusb
+
 RUN groupadd -g $USER_GID $USERNAME
 RUN useradd -s /bin/bash -u $USER_UID -g $USER_GID -G docker -m $USERNAME
 RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get -fy install git vim emacs sudo \
     build-essential cmake cppcheck valgrind \
     wget curl telnet \
     docker.io \
-    iputils-ping net-tools
+    iputils-ping net-tools \
+    libncurses5
 
 RUN python3 -m pip install pyocd pyusb
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,10 @@
         "--security-opt",
         "seccomp=unconfined",
         "--network=host",
-        "-v","/dev/bus/usb:/dev/bus/usb:ro",
-        "--device-cgroup-rule=a 189:* rmw"
+        "-v",
+        "/dev/bus/usb:/dev/bus/usb:ro",
+        "--device-cgroup-rule=a 189:* rmw",
+        "--add-host=host.docker.internal:host-gateway"
     ],
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
         "--cap-add=SYS_PTRACE",
         "--security-opt",
         "seccomp=unconfined",
-        "--network=host"
+        "--network=host",
+        "-v","/dev/bus/usb:/dev/bus/usb:ro",
+        "--device-cgroup-rule=a 189:* rmw"
     ],
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -83,6 +83,128 @@
                     "ignoreFailures": true
                 }
             ]
+        },
+        {
+            "name": "Shell Mbed Example Debug [NRF52840_DK]",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceRoot}/examples/shell/mbed",
+            "environment": [],
+            "externalConsole": false,
+            "debugServerArgs": "",
+            "serverLaunchTimeout": 20000,
+            "filterStderr": true,
+            "filterStdout": false,
+            "serverStarted": "GDB\\ server\\ started",
+            "logging": {
+                "moduleLoad": true,
+                "trace": true,
+                "engineLogging": true,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "linux": {
+                "MIMode": "gdb",
+                "MIDebuggerPath": "arm-none-eabi-gdb",
+                "debugServerPath": "pyocd-gdbserver"
+            },
+            "setupCommands": [
+                {
+                    "text": "-target-select remote localhost:3333",
+                    "description": "connect to target",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+                    "description": "load file",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor endian little\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor reset\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor halt\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-target-download",
+                    "description": "flash target",
+                    "ignoreFailures": false
+                }
+            ]
+        },
+        {
+            "name": "Shell Mbed Example Debug [DISCO_L475VG_IOT01A]",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceRoot}/examples/shell/mbed",
+            "environment": [],
+            "externalConsole": false,
+            "debugServerArgs": "",
+            "serverLaunchTimeout": 20000,
+            "filterStderr": true,
+            "filterStdout": false,
+            "serverStarted": "GDB\\ server\\ started",
+            "logging": {
+                "moduleLoad": true,
+                "trace": true,
+                "engineLogging": true,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "linux": {
+                "MIMode": "gdb",
+                "MIDebuggerPath": "arm-none-eabi-gdb",
+                "debugServerPath": "pyocd-gdbserver"
+            },
+            "setupCommands": [
+                {
+                    "text": "-target-select remote localhost:3333",
+                    "description": "connect to target",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
+                    "description": "load file",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor endian little\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor reset\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor halt\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-target-download",
+                    "description": "flash target",
+                    "ignoreFailures": false
+                }
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,64 +85,6 @@
             ]
         },
         {
-            "name": "Shell Mbed Example Debug [local]",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
-            "args": [],
-            "stopAtEntry": true,
-            "cwd": "${workspaceRoot}/examples/shell/mbed",
-            "environment": [],
-            "externalConsole": false,
-            "debugServerArgs": "",
-            "serverLaunchTimeout": 20000,
-            "filterStderr": true,
-            "filterStdout": false,
-            "serverStarted": "GDB\\ server\\ started",
-            "logging": {
-                "moduleLoad": true,
-                "trace": true,
-                "engineLogging": true,
-                "programOutput": true,
-                "exceptions": true
-            },
-            "setupCommands": [
-                {
-                    "text": "-target-select remote localhost:3333",
-                    "description": "connect to target",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
-                    "description": "load file",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor reset\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor halt\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-target-download",
-                    "description": "flash target",
-                    "ignoreFailures": false
-                }
-            ],
-            "linux": {
-                "MIMode": "gdb",
-                "MIDebuggerPath": "arm-none-eabi-gdb",
-                "debugServerPath": "pyocd-gdbserver",
-                "debugServerArgs": "" // [-t <stm32l475xg | nrf52840>]
-            }
-        },
-        {
             "name": "Shell Mbed Example Debug [remote]",
             "type": "cppdbg",
             "request": "launch",
@@ -196,6 +138,122 @@
             "linux": {
                 "MIMode": "gdb",
                 "MIDebuggerPath": "arm-none-eabi-gdb"
+            }
+        },
+        {
+            "name": "Shell Mbed Example Debug [local: nrf52840]",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceRoot}/examples/shell/mbed",
+            "environment": [],
+            "externalConsole": false,
+            "debugServerArgs": "",
+            "serverLaunchTimeout": 20000,
+            "filterStderr": true,
+            "filterStdout": false,
+            "serverStarted": "GDB\\ server\\ started",
+            "logging": {
+                "moduleLoad": true,
+                "trace": true,
+                "engineLogging": true,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "setupCommands": [
+                {
+                    "text": "-target-select remote localhost:3333",
+                    "description": "connect to target",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+                    "description": "load file",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor reset\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor halt\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-target-download",
+                    "description": "flash target",
+                    "ignoreFailures": false
+                }
+            ],
+            "linux": {
+                "MIMode": "gdb",
+                "MIDebuggerPath": "arm-none-eabi-gdb",
+                "debugServerPath": "pyocd-gdbserver",
+                "debugServerArgs": "-t nrf52840"
+            }
+        },
+        {
+            "name": "Shell Mbed Example Debug [local: stm32l475xg]",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceRoot}/examples/shell/mbed",
+            "environment": [],
+            "externalConsole": false,
+            "debugServerArgs": "",
+            "serverLaunchTimeout": 20000,
+            "filterStderr": true,
+            "filterStdout": false,
+            "serverStarted": "GDB\\ server\\ started",
+            "logging": {
+                "moduleLoad": true,
+                "trace": true,
+                "engineLogging": true,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "setupCommands": [
+                {
+                    "text": "-target-select remote localhost:3333",
+                    "description": "connect to target",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
+                    "description": "load file",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor reset\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor halt\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-target-download",
+                    "description": "flash target",
+                    "ignoreFailures": false
+                }
+            ],
+            "linux": {
+                "MIMode": "gdb",
+                "MIDebuggerPath": "arm-none-eabi-gdb",
+                "debugServerPath": "pyocd-gdbserver",
+                "debugServerArgs": "-t stm32l475xg"
             }
         }
     ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -88,7 +88,7 @@
             "name": "Shell Mbed Example Debug [remote]",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/${input:mbedProfile}/chip-mbed-shell-example",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${workspaceRoot}/examples/shell/mbed",
@@ -106,7 +106,7 @@
                     "ignoreFailures": false
                 },
                 {
-                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/${input:mbedProfile}/chip-mbed-shell-example",
                     "description": "load file",
                     "ignoreFailures": false
                 },
@@ -144,7 +144,7 @@
             "name": "Shell Mbed Example Debug [local: nrf52840]",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/${input:mbedProfile}/chip-mbed-shell-example",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${workspaceRoot}/examples/shell/mbed",
@@ -169,7 +169,7 @@
                     "ignoreFailures": false
                 },
                 {
-                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/${input:mbedProfile}/chip-mbed-shell-example",
                     "description": "load file",
                     "ignoreFailures": false
                 },
@@ -202,7 +202,7 @@
             "name": "Shell Mbed Example Debug [local: stm32l475xg]",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/${input:mbedProfile}/chip-mbed-shell-example",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${workspaceRoot}/examples/shell/mbed",
@@ -227,7 +227,7 @@
                     "ignoreFailures": false
                 },
                 {
-                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/${input:mbedProfile}/chip-mbed-shell-example",
                     "description": "load file",
                     "ignoreFailures": false
                 },
@@ -264,6 +264,13 @@
             "description": "What mbed target will be used?",
             "options": ["NRF52840_DK", "DISCO_L475VG_IOT01A"],
             "default": "NRF52840_DK"
+        },
+        {
+            "type": "pickString",
+            "id": "mbedProfile",
+            "description": "What mbed profile do you want to use?",
+            "options": ["debug", "develop"],
+            "default": "develop"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,7 +85,7 @@
             ]
         },
         {
-            "name": "Shell Mbed Example Debug",
+            "name": "Shell Mbed Example Debug [local]",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
@@ -106,11 +106,6 @@
                 "programOutput": true,
                 "exceptions": true
             },
-            "linux": {
-                "MIMode": "gdb",
-                "MIDebuggerPath": "arm-none-eabi-gdb",
-                "debugServerPath": "pyocd-gdbserver"
-            },
             "setupCommands": [
                 {
                     "text": "-target-select remote localhost:3333",
@@ -120,10 +115,6 @@
                 {
                     "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
                     "description": "load file",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor endian little\"",
                     "ignoreFailures": false
                 },
                 {
@@ -143,7 +134,69 @@
                     "description": "flash target",
                     "ignoreFailures": false
                 }
-            ]
+            ],
+            "linux": {
+                "MIMode": "gdb",
+                "MIDebuggerPath": "arm-none-eabi-gdb",
+                "debugServerPath": "pyocd-gdbserver",
+                "debugServerArgs": "" // [-t <stm32l475xg | nrf52840>]
+            }
+        },
+        {
+            "name": "Shell Mbed Example Debug [remote]",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceRoot}/examples/shell/mbed",
+            "environment": [],
+            "externalConsole": false,
+            "debugServerArgs": "",
+            "serverLaunchTimeout": 20000,
+            "filterStderr": true,
+            "filterStdout": false,
+            "serverStarted": "GDB\\ server\\ started",
+            "setupCommands": [
+                {
+                    "text": "-target-select remote host.docker.internal:3333",
+                    "description": "connect to target",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
+                    "description": "load file",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor reset\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor halt\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
+                    "ignoreFailures": false
+                },
+                {
+                    "text": "-target-download",
+                    "description": "flash target",
+                    "ignoreFailures": false
+                }
+            ],
+            "logging": {
+                "moduleLoad": true,
+                "trace": true,
+                "engineLogging": true,
+                "programOutput": true,
+                "exceptions": true
+            },
+            "linux": {
+                "MIMode": "gdb",
+                "MIDebuggerPath": "arm-none-eabi-gdb"
+            }
         }
     ],
     "inputs": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,10 +85,10 @@
             ]
         },
         {
-            "name": "Shell Mbed Example Debug [NRF52840_DK]",
+            "name": "Shell Mbed Example Debug",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+            "program": "${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
             "args": [],
             "stopAtEntry": true,
             "cwd": "${workspaceRoot}/examples/shell/mbed",
@@ -118,7 +118,7 @@
                     "ignoreFailures": false
                 },
                 {
-                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-NRF52840_DK/chip-mbed-shell-example",
+                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-${input:mbedTarget}/chip-mbed-shell-example",
                     "description": "load file",
                     "ignoreFailures": false
                 },
@@ -144,67 +144,15 @@
                     "ignoreFailures": false
                 }
             ]
-        },
+        }
+    ],
+    "inputs": [
         {
-            "name": "Shell Mbed Example Debug [DISCO_L475VG_IOT01A]",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
-            "args": [],
-            "stopAtEntry": true,
-            "cwd": "${workspaceRoot}/examples/shell/mbed",
-            "environment": [],
-            "externalConsole": false,
-            "debugServerArgs": "",
-            "serverLaunchTimeout": 20000,
-            "filterStderr": true,
-            "filterStdout": false,
-            "serverStarted": "GDB\\ server\\ started",
-            "logging": {
-                "moduleLoad": true,
-                "trace": true,
-                "engineLogging": true,
-                "programOutput": true,
-                "exceptions": true
-            },
-            "linux": {
-                "MIMode": "gdb",
-                "MIDebuggerPath": "arm-none-eabi-gdb",
-                "debugServerPath": "pyocd-gdbserver"
-            },
-            "setupCommands": [
-                {
-                    "text": "-target-select remote localhost:3333",
-                    "description": "connect to target",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-file-exec-and-symbols ${workspaceRoot}/examples/shell/mbed/build-DISCO_L475VG_IOT01A/chip-mbed-shell-example",
-                    "description": "load file",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor endian little\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor reset\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor halt\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-interpreter-exec console \"monitor arm semihosting enable\"",
-                    "ignoreFailures": false
-                },
-                {
-                    "text": "-target-download",
-                    "description": "flash target",
-                    "ignoreFailures": false
-                }
-            ]
+            "type": "pickString",
+            "id": "mbedTarget",
+            "description": "What mbed target will be used?",
+            "options": ["NRF52840_DK", "DISCO_L475VG_IOT01A"],
+            "default": "NRF52840_DK"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -233,7 +233,7 @@
             }
         },
         {
-            "label": "Build nRF mbed shell Example",
+            "label": "Build Mbed Shell example (NRF52840-DK)",
             "type": "shell",
             "command": "scripts/examples/mbed_example.sh",
             "args": ["-a=shell", "-b=NRF52840_DK", "-p=release"],
@@ -245,6 +245,36 @@
                     "${workspaceFolder}/examples/shell/mbed/build"
                 ]
             }
+        },
+        {
+            "label": "Build Mbed Shell example (DISCO_L475VG_IOT01A)",
+            "type": "shell",
+            "command": "scripts/examples/mbed_example.sh",
+            "args": ["-a=shell", "-b=DISCO_L475VG_IOT01A", "-p=release"],
+            "group": "build",
+            "problemMatcher": {
+                "base": "$gcc",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceFolder}/examples/shell/mbed/build"
+                ]
+            }
+        },
+        {
+            "label": "Flash Mbed Shell example (NRF52840-DK)",
+            "type": "shell",
+            "command": "scripts/examples/mbed_example_utils.sh",
+            "args": ["-a=shell", "-b=NRF52840_DK"],
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "label": "Flash Mbed Shell example (DISCO_L475VG_IOT01A)",
+            "type": "shell",
+            "command": "scripts/examples/mbed_example_utils.sh",
+            "args": ["-a=shell", "-b=DISCO_L475VG_IOT01A"],
+            "problemMatcher": [],
+            "group": "build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -233,10 +233,14 @@
             }
         },
         {
-            "label": "Build Mbed Shell example (NRF52840-DK)",
+            "label": "Build Mbed Shell Example",
             "type": "shell",
             "command": "scripts/examples/mbed_example.sh",
-            "args": ["-a=shell", "-b=NRF52840_DK", "-p=release"],
+            "args": [
+                "-a=shell",
+                "-b=${input:mbedTarget}",
+                "-p=${input:mbedProfile}"
+            ],
             "group": "build",
             "problemMatcher": {
                 "base": "$gcc",
@@ -247,34 +251,28 @@
             }
         },
         {
-            "label": "Build Mbed Shell example (DISCO_L475VG_IOT01A)",
-            "type": "shell",
-            "command": "scripts/examples/mbed_example.sh",
-            "args": ["-a=shell", "-b=DISCO_L475VG_IOT01A", "-p=release"],
-            "group": "build",
-            "problemMatcher": {
-                "base": "$gcc",
-                "fileLocation": [
-                    "relative",
-                    "${workspaceFolder}/examples/shell/mbed/build"
-                ]
-            }
-        },
-        {
-            "label": "Flash Mbed Shell example (NRF52840-DK)",
+            "label": "Flash Mbed Shell Example",
             "type": "shell",
             "command": "scripts/examples/mbed_example_utils.sh",
-            "args": ["-a=shell", "-b=NRF52840_DK"],
+            "args": ["-a=shell", "-b=${input:mbedTarget}"],
             "problemMatcher": [],
             "group": "build"
+        }
+    ],
+    "inputs": [
+        {
+            "type": "pickString",
+            "id": "mbedTarget",
+            "description": "What mbed target will be used?",
+            "options": ["NRF52840_DK", "DISCO_L475VG_IOT01A"],
+            "default": "NRF52840_DK"
         },
         {
-            "label": "Flash Mbed Shell example (DISCO_L475VG_IOT01A)",
-            "type": "shell",
-            "command": "scripts/examples/mbed_example_utils.sh",
-            "args": ["-a=shell", "-b=DISCO_L475VG_IOT01A"],
-            "problemMatcher": [],
-            "group": "build"
+            "type": "pickString",
+            "id": "mbedProfile",
+            "description": "What mbed profile do you want to use?",
+            "options": ["release", "debug", "develop"],
+            "default": "debug"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -254,7 +254,11 @@
             "label": "Flash Mbed Shell Example",
             "type": "shell",
             "command": "scripts/examples/mbed_example_utils.sh",
-            "args": ["-a=shell", "-b=${input:mbedTarget}"],
+            "args": [
+                "-a=shell",
+                "-b=${input:mbedTarget}",
+                "-p=${input:mbedProfile}"
+            ],
             "problemMatcher": [],
             "group": "build"
         }
@@ -272,7 +276,7 @@
             "id": "mbedProfile",
             "description": "What mbed profile do you want to use?",
             "options": ["release", "debug", "develop"],
-            "default": "debug"
+            "default": "develop"
         }
     ]
 }

--- a/scripts/examples/mbed_example_utils.sh
+++ b/scripts/examples/mbed_example_utils.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+cd "$(dirname "$0")/../../examples"
+
+SUPPORTED_TARGET_BOARD=(DISCO_L475VG_IOT01A NRF52840_DK)
+SUPPORTED_APP=(shell)
+
+APP=
+TARGET_BOARD=
+PYOCD_TARGET=
+
+for i in "$@"; do
+    case $i in
+    -a=* | --app=*)
+        APP="${i#*=}"
+        shift
+        ;;
+    -b=* | --board=*)
+        TARGET_BOARD="${i#*=}"
+        shift
+        ;;
+    *)
+        # unknown option
+        ;;
+    esac
+done
+
+case $TARGET_BOARD in
+NRF52840_DK)
+    PYOCD_TARGET=nrf52840
+    ;;
+
+DISCO_L475VG_IOT01A)
+    PYOCD_TARGET=stm32l475xg
+    ;;
+
+*)
+    # unknown option
+    ;;
+esac
+
+if [[ ! " ${SUPPORTED_TARGET_BOARD[@]} " =~ " ${TARGET_BOARD} " ]]; then
+    echo "ERROR: Target $TARGET_BOARD not supported"
+    exit 1
+fi
+
+if [[ ! " ${SUPPORTED_APP[@]} " =~ " ${APP} " ]]; then
+    echo "ERROR: Application $APP not supported"
+    exit 1
+fi
+
+echo "############################"
+pyocd flash -t $PYOCD_TARGET $PWD/$APP/mbed/build-$TARGET_BOARD/chip-mbed-$APP-example.hex
+echo "############################"

--- a/scripts/examples/mbed_example_utils.sh
+++ b/scripts/examples/mbed_example_utils.sh
@@ -20,10 +20,12 @@ cd "$(dirname "$0")/../../examples"
 
 SUPPORTED_TARGET_BOARD=(DISCO_L475VG_IOT01A NRF52840_DK)
 SUPPORTED_APP=(shell)
+SUPPORTED_PROFILES=(release develop debug)
 
 APP=
 TARGET_BOARD=
 PYOCD_TARGET=
+PROFILE=
 
 for i in "$@"; do
     case $i in
@@ -33,6 +35,10 @@ for i in "$@"; do
         ;;
     -b=* | --board=*)
         TARGET_BOARD="${i#*=}"
+        shift
+        ;;
+    -p=* | --profile=*)
+        PROFILE="${i#*=}"
         shift
         ;;
     *)
@@ -65,6 +71,11 @@ if [[ ! " ${SUPPORTED_APP[@]} " =~ " ${APP} " ]]; then
     exit 1
 fi
 
+if [[ ! " ${SUPPORTED_PROFILES[@]} " =~ " ${PROFILE} " ]]; then
+    echo "ERROR: Profile $PROFILE not supported"
+    exit 1
+fi
+
 echo "############################"
-pyocd flash -t $PYOCD_TARGET $PWD/$APP/mbed/build-$TARGET_BOARD/chip-mbed-$APP-example.hex
+pyocd flash -t $PYOCD_TARGET $PWD/$APP/mbed/build-$TARGET_BOARD/$PROFILE/chip-mbed-$APP-example.hex
 echo "############################"


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Missing capability to flash and debug mbed shell examples in vscode.

As someone may notice, I didn't change profile of build  shell application to 'debug' - ConnectivyManagerImpl.h stub causes a problem when we want to build application with debug profile (undefined reference in multiple places). 
I decided to not fix this issue within this change because problem probably will be solved when we merge wifi or ble work into 'development' branch (as they extend ConnectivityManagerImpl.h) 

After switching to Mbed 6.7.0 and mbed-tools 7.1.2 it is possible to have separated build directory depending
on mbed application profile. This change includes that 'feature'

I observed that for STLink probe, the gdbserver can't automatically detect debug target if it's run inside container. This is related to limited access to host mounted volumes inside container,  which are used by STLink to pass information about connected stm hardware. In result,breakpoints doesn't work properly during debugging. 
We may workaround this issue by passing directly target name to gdbserver and for that reason I decided to use fixed configuration for debug tasks which are run inside container. 

In result we will have below tasks:

[Build]

- `Build Mbed Shell Example` (target and profile selected via input variables)

- `Flash Mbed Shell Example` (target and profile selected via input variables) [requires linux host]

[Debug]

- `Shell Mbed Example Debug [remote]` - it will try to connect with host `pyocd-gdbserver --allow-remote` server. Should work on every system. Target and profile selected via input variables.
- `Shell Mbed Example Debug [local stm32l475xg]` (profile selected via input variables) -  gdbserver will run inside container, requires linux host for proper connection with HW.
- `Shell Mbed Example Debug [local nrf52840]` (profile selected via input variables) -  gdbserver will run inside container, requires linux host for proper connection with HW.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Update .devcontainer.json to pass through usb debug probe from host to vscode container.
Add flash tasks to tasks.json, add sepearted tast for building shell example on DISCO board and rename build tasks.
Add debug launch configuration for debugging mbed shell example.
Add pyocd, pyusb modules to the final vscode container.
Add mbed_example_utils.sh helper script for simplify calling pyocd within vscode tasks.


<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #74
 Fixes #75 

This change requires  #88.


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
