### PR TITLE
Fix too many warnings in Mbed variant of CHIP build

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -136,7 +136,6 @@ config("optimize_default") {
 config("disabled_warnings") {
   cflags = [
     "-Wno-deprecated-declarations",
-    "-Wno-unknown-warning-option",
     "-Wno-missing-field-initializers",
     "-Wno-unused-parameter",
   ]
@@ -149,6 +148,9 @@ config("disabled_warnings") {
       "-Wno-psabi",
       "-Wno-cast-function-type",
     ]
+  }
+  else {
+    cflags += [ "-Wno-unknown-warning-option" ]
   }
 }
 

--- a/config/mbed/chip-gn/.gn
+++ b/config/mbed/chip-gn/.gn
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+
 # The location of the build configuration file.
 buildconfig = "//build/config/BUILDCONFIG.gn"
 
@@ -21,6 +23,10 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "mbed"
+
+  default_configs_warnings = [
+    "${build_root}/config/compiler:warnings_default",
+    "//:chip_custom_cflags_config"]
 
   import("//args.gni")
 }

--- a/config/mbed/chip-gn/.gn
+++ b/config/mbed/chip-gn/.gn
@@ -26,7 +26,8 @@ default_args = {
 
   default_configs_warnings = [
     "${build_root}/config/compiler:warnings_default",
-    "//:chip_custom_cflags_config"]
+    "//:chip_custom_cflags_config"
+    ]
 
   import("//args.gni")
 }

--- a/config/mbed/chip-gn/BUILD.gn
+++ b/config/mbed/chip-gn/BUILD.gn
@@ -19,6 +19,11 @@ assert(current_os == "mbed")
 
 declare_args() {
   chip_build_libshell = false
+  chip_custom_build_cflags = []
+}
+
+config("chip_custom_cflags_config") {
+  cflags = chip_custom_build_cflags
 }
 
 group("mbed") {

--- a/config/mbed/chip-gn/args.gni
+++ b/config/mbed/chip-gn/args.gni
@@ -23,7 +23,9 @@ chip_device_project_config_include = ""
 
 chip_custom_build_cflags = [
     "-Wno-shadow",
-    "-Wno-conversion"
+    "-Wno-conversion",
+    "-Wno-maybe-uninitialized",
+    "-Wno-return-type"
     ]
 
 custom_toolchain = "//toolchain:mbed"

--- a/config/mbed/chip-gn/args.gni
+++ b/config/mbed/chip-gn/args.gni
@@ -21,6 +21,11 @@ chip_project_config_include = ""
 chip_system_project_config_include = ""
 chip_device_project_config_include = ""
 
+chip_custom_build_cflags = [
+    "-Wno-shadow",
+    "-Wno-conversion"
+    ]
+
 custom_toolchain = "//toolchain:mbed"
 mbedtls_target = "//mbedtls:mbedtls"
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Too many warnings are present in Mbed variant of CHIP build.


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add `chip_custom_cflags_config` and `chip_custom_build_cflags` argument to mbed-chip gn config files. 
By adding compiler flags to `chip_custom_build_cflags` user can overwrite default warnings configuration and can for example disable `-Wshadow` option. 
This change doesn't modify main chip gn configuration and is only limited to mbed platform gn config.

Add condition for adding '-Wno-unknown-warning-option' flag only if the clang compiler is used.
GCC does not support that flag and it will only complain about it if there are other errors/warnings in the file.   

Mbed project and CHIP still use separated set of compiler flags.

New build output log can be reviewed by looking into:
https://github.com/ARMmbed/connectedhomeip/runs/2027358055?check_suite_focus=true
https://github.com/ARMmbed/connectedhomeip/runs/2027358024?check_suite_focus=true
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #56 

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
