### PR TITLE
Add routine to convert memory order from GCC into Mbed

### DIFF
--- a/examples/shell/mbed/arch.c
+++ b/examples/shell/mbed/arch.c
@@ -43,11 +43,9 @@ uint64_t __atomic_exchange_8(volatile void* ptr, uint64_t val, int memorder) {
 }
 
 
-bool __atomic_compare_exchange_8(volatile void *ptr, void*expected, uint64_t desired, bool weak, int success_memorder, int failure_memorder)
+// Note: Weak version not supported in library, the weak parameter is simply dropped.
+// see https://gcc.gnu.org/wiki/Atomic/GCCMM/LIbrary
+bool __atomic_compare_exchange_8(volatile void *ptr, void*expected, unsigned long long desired, int success_memorder, int failure_memorder)
 {
-    if (weak) {
-        return core_util_atomic_compare_exchange_weak_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, mem_order(success_memorder), mem_order(failure_memorder));
-    } else {
-        return core_util_atomic_cas_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, mem_order(success_memorder), mem_order(failure_memorder));
-    }
+    return core_util_atomic_cas_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, mem_order(success_memorder), mem_order(failure_memorder));
 }

--- a/examples/shell/mbed/arch.c
+++ b/examples/shell/mbed/arch.c
@@ -4,28 +4,50 @@
 // TODO: Remove!
 // This file is a temporary workaround until atomic integration has been solved
 
+static mbed_memory_order mem_order(int order) { 
+    switch (order)
+    {
+    case __ATOMIC_RELAXED:
+        return mbed_memory_order_relaxed;
+    case __ATOMIC_CONSUME:
+        return mbed_memory_order_consume;
+    case __ATOMIC_ACQUIRE:
+        return mbed_memory_order_acquire;        
+    case __ATOMIC_RELEASE:
+        return mbed_memory_order_release;                
+    case __ATOMIC_ACQ_REL:
+        return mbed_memory_order_acq_rel;        
+    case __ATOMIC_SEQ_CST:
+        return mbed_memory_order_seq_cst;                
+    default:
+        // Should not happen! return sequential consistency in such case
+        MBED_ASSERT(false);
+        return mbed_memory_order_seq_cst;                
+    }
+}
+
 void __sync_synchronize() { 
     MBED_BARRIER();
 }
 
 unsigned int __atomic_fetch_add_4(volatile void *ptr, unsigned int val, int memorder) { 
-    return core_util_atomic_fetch_add_explicit_u32((volatile uint32_t*)ptr, val, memorder);
+    return core_util_atomic_fetch_add_explicit_u32((volatile uint32_t*)ptr, val, mem_order(memorder));
 }
 
 uint64_t __atomic_load_8(const volatile void* ptr, int memorder) {
-    return core_util_atomic_load_explicit_u64((const volatile uint64_t*)ptr, memorder);
+    return core_util_atomic_load_explicit_u64((const volatile uint64_t*)ptr, mem_order(memorder));
 }
 
 uint64_t __atomic_exchange_8(volatile void* ptr, uint64_t val, int memorder) {
-    return core_util_atomic_exchange_explicit_u64((volatile uint64_t*)ptr, val, memorder);
+    return core_util_atomic_exchange_explicit_u64((volatile uint64_t*)ptr, val, mem_order(memorder));
 }
 
 
 bool __atomic_compare_exchange_8(volatile void *ptr, void*expected, uint64_t desired, bool weak, int success_memorder, int failure_memorder)
 {
     if (weak) {
-        return core_util_atomic_compare_exchange_weak_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, success_memorder, failure_memorder);
+        return core_util_atomic_compare_exchange_weak_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, mem_order(success_memorder), mem_order(failure_memorder));
     } else {
-        return core_util_atomic_cas_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, success_memorder, failure_memorder);
+        return core_util_atomic_cas_explicit_u64((volatile uint64_t*)ptr, (uint64_t*)expected, desired, mem_order(success_memorder), mem_order(failure_memorder));
     }
 }


### PR DESCRIPTION

 #### Problem
 GCC atomic memory order differs from Mbed this causes an hardfault in backend implementation.

 #### Summary of Changes
Add a routine to convert GCC memory order into mbed one. 

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #<<<<<FILL ME IN  - issue number(s). If no issue, please create one>>>>>

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
