### PR TITLE
Improve pyOCD flashing performance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -195,7 +195,7 @@
                 "MIMode": "gdb",
                 "MIDebuggerPath": "arm-none-eabi-gdb",
                 "debugServerPath": "pyocd-gdbserver",
-                "debugServerArgs": "-t nrf52840"
+                "debugServerArgs": "-t nrf52840 -O connect_mode=under-reset"
             }
         },
         {
@@ -253,7 +253,7 @@
                 "MIMode": "gdb",
                 "MIDebuggerPath": "arm-none-eabi-gdb",
                 "debugServerPath": "pyocd-gdbserver",
-                "debugServerArgs": "-t stm32l475xg"
+                "debugServerArgs": "-t stm32l475xg -O connect_mode=under-reset -f 4000000"
             }
         }
     ],

--- a/scripts/examples/mbed_example_utils.sh
+++ b/scripts/examples/mbed_example_utils.sh
@@ -25,6 +25,7 @@ SUPPORTED_PROFILES=(release develop debug)
 APP=
 TARGET_BOARD=
 PYOCD_TARGET=
+PYOCD_TARGET_ARGS=
 PROFILE=
 
 for i in "$@"; do
@@ -54,6 +55,7 @@ NRF52840_DK)
 
 DISCO_L475VG_IOT01A)
     PYOCD_TARGET=stm32l475xg
+    PYOCD_TARGET_ARGS="--frequency 4M"
     ;;
 
 *)
@@ -77,5 +79,5 @@ if [[ ! " ${SUPPORTED_PROFILES[@]} " =~ " ${PROFILE} " ]]; then
 fi
 
 echo "############################"
-pyocd flash -t $PYOCD_TARGET -O connect_mode=under-reset $PWD/$APP/mbed/build-$TARGET_BOARD/$PROFILE/chip-mbed-$APP-example.hex
+pyocd flash -t $PYOCD_TARGET -O connect_mode=under-reset $PYOCD_TARGET_ARGS $PWD/$APP/mbed/build-$TARGET_BOARD/$PROFILE/chip-mbed-$APP-example.hex
 echo "############################"

--- a/scripts/examples/mbed_example_utils.sh
+++ b/scripts/examples/mbed_example_utils.sh
@@ -77,5 +77,5 @@ if [[ ! " ${SUPPORTED_PROFILES[@]} " =~ " ${PROFILE} " ]]; then
 fi
 
 echo "############################"
-pyocd flash -t $PYOCD_TARGET $PWD/$APP/mbed/build-$TARGET_BOARD/$PROFILE/chip-mbed-$APP-example.hex
+pyocd flash -t $PYOCD_TARGET -O connect_mode=under-reset $PWD/$APP/mbed/build-$TARGET_BOARD/$PROFILE/chip-mbed-$APP-example.hex
 echo "############################"


### PR DESCRIPTION
 #### Problem
Flashing the DISCO is unstable and it takes quite some time to complete (when it works).

 #### Summary of Changes
Add `pyOCD flash` args:
- `-O connect_mode=under-reset` for every target -- this fixes stability,
- `--frequency 4M` -- this sets the STLink speed to max, to shorten the transfer times.
