### PR TITLE
Fix getaddrinfo(), result buffer allocation and set hinst IP type

### DIFF
--- a/src/platform/mbed/net/src/net_dns.cpp
+++ b/src/platform/mbed/net/src/net_dns.cpp
@@ -32,8 +32,13 @@ int mbed_getaddrinfo(const char * nodename, const char * servname, const struct 
     case AF_INET6:
         sHints.set_addr({ NSAPI_IPv6, 0 });
         break;
-    default:
-        return EAI_FAMILY;
+    }
+
+    result = new SocketAddress[MBED_CONF_NSAPI_DNS_ADDRESSES_LIMIT];
+    if (result == nullptr)
+    {
+        set_errno(ENOMEM);
+        return EAI_SYSTEM;
     }
 
     err = net->getaddrinfo(nodename, &sHints, &result);


### PR DESCRIPTION
 #### Problem
mbed_getaddrinfo() bug: result buffer is not allocated and wrong settings hint IP type

 #### Summary of Changes
Fix mbed_getaddrinfo() - result buffer allocation and set hints IP type
